### PR TITLE
Remove either dependency

### DIFF
--- a/Jose/Internal/Parser.hs
+++ b/Jose/Internal/Parser.hs
@@ -17,6 +17,7 @@ module Jose.Internal.Parser
 where
 
 import           Control.Applicative
+import           Data.Bifunctor (first)
 import Data.Aeson (eitherDecodeStrict')
 import           Data.Attoparsec.ByteString (Parser)
 import qualified Data.Attoparsec.ByteString as P
@@ -24,7 +25,6 @@ import qualified Data.Attoparsec.ByteString.Char8 as PC
 import           Data.ByteArray.Encoding (convertFromBase, Base(..))
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as B
-import           Data.Either.Combinators (mapLeft)
 
 import           Jose.Jwa
 import           Jose.Types (JwtError(..), JwtHeader(..), JwsHeader(..), JweHeader(..))
@@ -55,7 +55,7 @@ newtype EncryptedCEK = EncryptedCEK ByteString
 
 
 parseJwt :: ByteString -> Either JwtError DecodableJwt
-parseJwt bs = mapLeft (const BadCrypto) $ P.parseOnly jwt bs
+parseJwt bs = first (const BadCrypto) $ P.parseOnly jwt bs
 
 
 jwt :: Parser DecodableJwt

--- a/jose-jwt.cabal
+++ b/jose-jwt.cabal
@@ -55,7 +55,6 @@ Library
                     , cereal >= 0.4
                     , containers >= 0.4
                     , cryptonite >= 0.19
-                    , either
                     , memory >= 0.10
                     , mtl >= 2.1.3.1
                     , text  >= 0.11
@@ -77,7 +76,6 @@ Test-suite tests
                     , aeson
                     , bytestring
                     , cryptonite
-                    , either >= 4.0
                     , memory
                     , mtl
                     , text


### PR DESCRIPTION
This PR makes it so that `jose-jwt` no longer depends on `either`. Among other things, this makes it easier to cross-compile, but it generally means `jose-jwt` has a smaller dependency footprint. 