### PR TITLE
Add more JWE and JWS algorithms

### DIFF
--- a/Jose/Jwa.hs
+++ b/Jose/Jwa.hs
@@ -18,20 +18,24 @@ import Data.Tuple (swap)
 -- | General representation of the @alg@ JWT header value.
 data Alg = Signed JwsAlg | Encrypted JweAlg deriving (Eq, Show)
 
--- | A subset of the signature algorithms from the
+-- | The signature algorithms from the
 -- <https://tools.ietf.org/html/rfc7518#section-3 JWA Spec>.
-data JwsAlg = None | HS256 | HS384 | HS512 | RS256 | RS384 | RS512 | ES256 | ES384 | ES512 | EdDSA deriving (Eq, Show, Read)
+--
+-- NB: @PS256@, @PS384@ and @PS512@ algorithms aren't implemented yet.
+data JwsAlg = None | HS256 | HS384 | HS512 | RS256 | RS384 | RS512 | ES256 | ES384 | ES512 | PS256 | PS384 | PS512 | EdDSA deriving (Eq, Show, Read)
 
--- | A subset of the key management algorithms from the
+-- | The key management algorithms from the
 -- <https://tools.ietf.org/html/rfc7518#section-4 JWA Spec>.
-data JweAlg = RSA1_5 | RSA_OAEP | RSA_OAEP_256 | A128KW | A192KW | A256KW deriving (Eq, Show, Read)
+--
+-- NB: @ECDH_ES@, @ECDH_ES_A128KW@, @ECDH_ES_A192KW@ and @DIR@ algorithms aren't implemented yet.
+data JweAlg = RSA1_5 | RSA_OAEP | RSA_OAEP_256 | A128KW | A192KW | A256KW | ECDH_ES | ECDH_ES_A128KW | ECDH_ES_A192KW | DIR deriving (Eq, Show, Read)
 
 -- | Content encryption algorithms from the
 -- <https://tools.ietf.org/html/rfc7518#section-5 JWA Spec>.
 data Enc = A128CBC_HS256 | A192CBC_HS384 | A256CBC_HS512 | A128GCM | A192GCM | A256GCM deriving (Eq, Show)
 
 algs :: [(Text, Alg)]
-algs = [("none", Signed None), ("HS256", Signed HS256), ("HS384", Signed HS384), ("HS512", Signed HS512), ("RS256", Signed RS256), ("RS384", Signed RS384), ("RS512", Signed RS512), ("ES256", Signed ES256), ("ES384", Signed ES384), ("ES512", Signed ES512), ("EdDSA", Signed EdDSA), ("RSA1_5", Encrypted RSA1_5), ("RSA-OAEP", Encrypted RSA_OAEP), ("RSA-OAEP-256", Encrypted RSA_OAEP_256), ("A128KW", Encrypted A128KW), ("A192KW", Encrypted A192KW), ("A256KW", Encrypted A256KW)]
+algs = [("none", Signed None), ("HS256", Signed HS256), ("HS384", Signed HS384), ("HS512", Signed HS512), ("RS256", Signed RS256), ("RS384", Signed RS384), ("RS512", Signed RS512), ("ES256", Signed ES256), ("ES384", Signed ES384), ("ES512", Signed ES512), ("PS256", Signed PS256), ("PS384", Signed PS384), ("PS512", Signed PS512), ("EdDSA", Signed EdDSA), ("RSA1_5", Encrypted RSA1_5), ("RSA-OAEP", Encrypted RSA_OAEP), ("RSA-OAEP-256", Encrypted RSA_OAEP_256), ("A128KW", Encrypted A128KW), ("A192KW", Encrypted A192KW), ("A256KW", Encrypted A256KW), ("ECDH-ES", Encrypted ECDH_ES), ("ECDH-ES+A128KW", Encrypted ECDH_ES_A128KW), ("ECDH-ES+A192KW", Encrypted ECDH_ES_A192KW), ("dir", Encrypted DIR)]
 
 algName :: Alg -> Text
 algName a = let Just n = lookup a algNames in n


### PR DESCRIPTION
This change adds the missing JWS and JWE algorithms. It doesn't add any new JWK constructors that can use these algorithms. But even so it's very beneficial to have them in the enums, so that if a server has any of these algorithms in their JWK set, the parsing isn't breaking.

The actual support for signing or encrypting JWK with these algorithms can be added later.