### PR TITLE
Add `eitherDecodeClaims`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0
+-----
+
+* Add an error message to `BadClaims`
+* Use `eitherDecodeStrict'` in `decodeClaims`
+
 0.9.3
 -----
 

--- a/Jose/Jwt.hs
+++ b/Jose/Jwt.hs
@@ -24,6 +24,7 @@ module Jose.Jwt
     , encode
     , decode
     , decodeClaims
+    , eitherDecodeClaims
     )
 where
 
@@ -33,7 +34,7 @@ import Control.Monad.Trans.Except
 import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
 import Crypto.PubKey.RSA (PrivateKey(..))
 import Crypto.Random (MonadRandom)
-import Data.Aeson (decodeStrict',FromJSON)
+import Data.Aeson (decodeStrict', eitherDecodeStrict', FromJSON)
 import Data.ByteString (ByteString)
 import Data.Maybe (isNothing)
 import qualified Data.ByteString.Char8 as BC
@@ -60,8 +61,11 @@ encode :: MonadRandom m
 encode jwks encoding msg = runExceptT $ case encoding of
     JwsEncoding None -> case msg of
         Claims p -> return $ Jwt $ BC.intercalate "." [unsecuredHdr, B64.encode p]
-        Nested _ -> throwE BadClaims
-    JwsEncoding a    -> case filter (canEncodeJws a) jwks of
+        Nested Jwt {unJwt = p} ->
+          throwE
+          . BadClaims
+          $ "Encoding failed. Payload: " <> BC.unpack  p
+    JwsEncoding a -> case filter (canEncodeJws a) jwks of
         []    -> throwE (KeyError "No matching key found for JWS algorithm")
         (k:_) -> ExceptT . return =<< lift (Jws.jwkEncode a k msg)
     JweEncoding a e -> case filter (canEncodeJwe a) jwks of
@@ -145,4 +149,26 @@ decodeClaims jwt = do
     claims <- B64.decode ((head . tail) components) >>= parseClaims
     return (hdr, claims)
   where
-    parseClaims bs = maybe (Left BadClaims) Right $ decodeStrict' bs
+    parseClaims bs =
+      maybe
+      ( Left
+      $ BadClaims
+        "Failed to decode claims. For more details, use `eitherDecodeClaims`."
+      )
+      Right $ decodeStrict' bs
+
+-- | The same as @decodeClaims@ but the error message is preserved
+-- in case of parsing failure.
+eitherDecodeClaims :: (FromJSON a)
+    => ByteString
+    -> Either JwtError (JwtHeader, a)
+eitherDecodeClaims jwt = do
+    let components = BC.split '.' jwt
+    when (length components /= 3) $ Left $ BadDots 2
+    hdr    <- B64.decode (head components) >>= parseHeader
+    claims <- B64.decode ((head . tail) components) >>= parseClaims
+    return (hdr, claims)
+  where
+    parseClaims bs = case eitherDecodeStrict' bs of
+      Left err -> Left $ BadClaims err
+      Right res -> return res

--- a/Jose/Types.hs
+++ b/Jose/Types.hs
@@ -155,7 +155,7 @@ data JwtError = KeyError Text      -- ^ No suitable key or wrong key type
               | BadAlgorithm Text  -- ^ The supplied algorithm is invalid
               | BadDots Int        -- ^ Wrong number of "." characters in the JWT
               | BadHeader Text     -- ^ Header couldn't be decoded or contains bad data
-              | BadClaims          -- ^ Claims part couldn't be decoded or contains bad data
+              | BadClaims String   -- ^ Claims part couldn't be decoded or contains bad data
               | BadSignature       -- ^ Signature is invalid
               | BadCrypto          -- ^ A cryptographic operation failed
               | Base64Error String -- ^ A base64 decoding error

--- a/jose-jwt.cabal
+++ b/jose-jwt.cabal
@@ -1,5 +1,5 @@
 Name:               jose-jwt
-Version:            0.9.3
+Version:            1.0
 Synopsis:           JSON Object Signing and Encryption Library
 Homepage:           http://github.com/tekul/jose-jwt
 Bug-Reports:        http://github.com/tekul/jose-jwt/issues

--- a/tests/Tests/JwsSpec.hs
+++ b/tests/Tests/JwsSpec.hs
@@ -64,8 +64,8 @@ spec = do
            let Right (_, claims) = decodeClaims a21 :: Either JwtError (JwtHeader, JwtClaims)
            jwtIss claims @?= Just "joe"
 
-        it "eitherDecodeClaims raises the right error upon parsing failure" $ do
-           let Left (BadClaims err) = eitherDecodeClaims a21JSONArray :: Either JwtError (JwtHeader, JwtClaims)
+        it "raises the right error upon parsing failure" $ do
+           let Left (BadClaims err) = decodeClaims a21JSONArray :: Either JwtError (JwtHeader, JwtClaims)
            err @?= "Error in $: JwtClaims must be an object"
 
         it "encodes the payload to the expected JWT" $ do

--- a/tests/Tests/JwsSpec.hs
+++ b/tests/Tests/JwsSpec.hs
@@ -64,6 +64,10 @@ spec = do
            let Right (_, claims) = decodeClaims a21 :: Either JwtError (JwtHeader, JwtClaims)
            jwtIss claims @?= Just "joe"
 
+        it "eitherDecodeClaims raises the right error upon parsing failure" $ do
+           let Left (BadClaims err) = eitherDecodeClaims a21JSONArray :: Either JwtError (JwtHeader, JwtClaims)
+           err @?= "Error in $: JwtClaims must be an object"
+
         it "encodes the payload to the expected JWT" $ do
           let sign = either (error "Sign failed") id . RSAPKCS15.sign Nothing (Just SHA256) rsaPrivateKey
           signWithHeader sign a21Header a21Payload @?= a21
@@ -172,6 +176,7 @@ a11jwk = "{\"kty\":\"oct\", \"k\":\"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T
 a21Header = "{\"alg\":\"RS256\"}" :: B.ByteString
 a21Payload = a11Payload
 a21 = "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"
+a21JSONArray = "eyJhbGciOiJSUzI1NiJ9.W10.cC4hiUPoj9Eetdgtv3hF80EGrhuB__dzERat0XF9g2VtQgr9PJbu3XOiZj5RZmh7AAuHIm4Bh-0Qc_lF5YKt_O8W2Fp5jujGbds9uJdbF9CUAr7t1dnZcAcQjbKBYNX4BAynRFdiuB--f_nZLgrnbyTyWzO75vRK5h6xBArLIARNPvkSjtQBMHlb1L07Qe7K0GarZRmB_eSN9383LcOLn6_dO--xi12jzDwusC-eOkHWEsqtFZESc6BfI7noOPqvhJ1phCnvWh6IeYI2w9QOYEUipUTI8np6LbgGY9Fs98rqVt5AXLIhWkWywlVmtVrBp0igcN_IoypGlUPQGe77Rw"
 a21jwk = "{\"kty\":\"RSA\", \"n\":\"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddxHmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMsD1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSHSXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdVMTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ\", \"e\":\"AQAB\", \"d\":\"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97IjlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYTCBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLhBOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ\"}"
 
 a31Header = "{\"alg\":\"ES256\"}" :: B.ByteString


### PR DESCRIPTION
As discussed here: https://github.com/tekul/jose-jwt/issues/35 , this PR adds a utility function which preserves the error messages when decoding claims. @tekul, I was bold enough to add a `String` parameter to the `BadClaims` error. Let me know if this is acceptable or you would rather see me introduce a new error constructor. 