### PR TITLE
chore: bump aeson bound to allow 2.1, add CI for newer GHC versions

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,15 +8,21 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        ghc:
+          - 8.10.7
+          - 9.2.5
+          - 9.4.3
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v1
+    - uses: haskell/actions/setup@v2
       with:
-        ghc-version: '8.10.3'
-        cabal-version: '3.2'
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: '3.8.1.0'
 
     - name: Cache
       uses: actions/cache@v2

--- a/jose-jwt.cabal
+++ b/jose-jwt.cabal
@@ -50,7 +50,7 @@ Library
     Buildable: False
   else
     Build-depends:    base >= 4.9 && < 5
-                    , aeson >= 1.5 && < 2.1
+                    , aeson >= 1.5 && < 2.2
                     , attoparsec >= 0.12.0.0
                     , bytestring >= 0.9
                     , cereal >= 0.4


### PR DESCRIPTION
Tests pass on 9.4.3. Can you do a metadata revision on Hackage with these bounds? Thanks!