### PR TITLE
Using ram package instead of memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .cabal-sandbox
 .stack-work/
 cabal.sandbox.config
+cabal.project.freeze
 .ghc.environment*
 *.swp
 dist/
@@ -14,4 +15,3 @@ result
 *.aux
 *.hp
 tags
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.11.0
+------
+
+* Switch to `crypton` >= 1.1.0 and replace the `memory` package with the `ram` package.
+
 0.10.0
 ------
 

--- a/jose-jwt.cabal
+++ b/jose-jwt.cabal
@@ -54,15 +54,12 @@ Library
                     , attoparsec >= 0.12.0.0
                     , bytestring >= 0.9
                     , cereal >= 0.4
-                    , containers >= 0.4
-                    , crypton >= 0.32
-                    , memory >= 0.10
+                    , crypton >= 1.1.0 && < 1.2
+                    , ram >= 0.21
                     , mtl >= 2.1.3.1
                     , text  >= 0.11
                     , time  >= 1.4
                     , transformers >= 0.3
-                    , transformers-compat >= 0.4
-                    , unordered-containers >= 0.2
                     , vector >= 0.10
   Ghc-Options:        -Wall
 
@@ -77,10 +74,7 @@ Test-suite tests
                     , aeson
                     , bytestring
                     , crypton
-                    , memory
-                    , mtl
-                    , text
-                    , unordered-containers
+                    , ram
                     , vector
                     , hspec >= 1.6
                     , HUnit >= 1.2

--- a/jose-jwt.cabal
+++ b/jose-jwt.cabal
@@ -1,5 +1,5 @@
 Name:               jose-jwt
-Version:            0.10.0
+Version:            0.11.0
 Synopsis:           JSON Object Signing and Encryption Library
 Homepage:           http://github.com/tekul/jose-jwt
 Bug-Reports:        http://github.com/tekul/jose-jwt/issues
@@ -54,11 +54,11 @@ Library
                     , attoparsec >= 0.12.0.0
                     , bytestring >= 0.9
                     , cereal >= 0.4
-                    , crypton >= 1.1.0 && < 1.2
+                    , crypton >= 1.1.0
                     , ram >= 0.21
                     , mtl >= 2.1.3.1
-                    , text  >= 0.11
-                    , time  >= 1.4
+                    , text >= 0.11
+                    , time >= 1.4
                     , transformers >= 0.3
                     , vector >= 0.10
   Ghc-Options:        -Wall
@@ -92,7 +92,7 @@ Test-suite doctests
   if !flag(doctest)
     Buildable: False
   else
-    Build-depends:    base  >= 4.9 && < 5
+    Build-depends:    base >= 4.9 && < 5
                     , doctest >= 0.9.11
                     , crypton
 


### PR DESCRIPTION
This PR proposes to:
- Bump the package version.
- Bump the minimum supported version of `crypton`.
- Replace the `memory` package with the new `ram` package.
  - https://jappie.me/announcement-memory-ram-fork.html
  - https://github.com/kazu-yamamoto/crypton/commit/2537c7951f3ccfb1bc8b1bff65b75eae87372fc2
- Remove unused dependencies.