### PR TITLE
Allow aeson 2.3

### DIFF
--- a/jose-jwt.cabal
+++ b/jose-jwt.cabal
@@ -50,7 +50,7 @@ Library
     Buildable: False
   else
     Build-depends:    base >= 4.9 && < 5
-                    , aeson >= 1.5 && < 2.3
+                    , aeson >= 1.5 && < 2.4
                     , attoparsec >= 0.12.0.0
                     , bytestring >= 0.9
                     , cereal >= 0.4


### PR DESCRIPTION
https://hackage.haskell.org/package/aeson-2.3.0.0/changelog
https://haskell.github.io/security-advisories/advisory/HSEC-2026-0007.html

Built and tested with --constraint=aeson==2.3.0.0